### PR TITLE
v2.2.0 compatible schema

### DIFF
--- a/batoms_api/api/schema.yaml
+++ b/batoms_api/api/schema.yaml
@@ -55,7 +55,7 @@ settings:
       segments: { _disabled: true }
     update: { _type: _bool }
 
-  bonds:
+  bond:
     show_hydrogen_bond: { _type: _bool }
     show_search: { _type: _bool }
     setting:
@@ -69,7 +69,7 @@ settings:
         style: { _type: [_int, _str] }
         width: { _type: _float }
 
-  polyhedras:
+  polyhedra:
     setting:
       _any:
         show_edge: { _type: _bool }
@@ -78,7 +78,7 @@ settings:
         width: { _type: _float }
         material_style: { _type: _str, _disabled: true }
 
-  isosurfaces:
+  isosurface:
     setting:
       _any:
         level: { _type: _float }
@@ -113,7 +113,7 @@ settings:
         width: { _type: _float }
     draw: { _type: _bool }
 
-  ms:
+  molecular_surface:
     setting:
       _any:
         type: { _type: _str }

--- a/batoms_api/api/schema.yaml
+++ b/batoms_api/api/schema.yaml
@@ -58,7 +58,7 @@ settings:
   bond:
     show_hydrogen_bond: { _type: _bool }
     show_search: { _type: _bool }
-    setting:
+    settings:
       _any:
         _eval_key: true
         max: { _type: _float }
@@ -70,7 +70,7 @@ settings:
         width: { _type: _float }
 
   polyhedra:
-    setting:
+    settings:
       _any:
         show_edge: { _type: _bool }
         flag: { _type: _bool }
@@ -79,13 +79,14 @@ settings:
         material_style: { _type: _str, _disabled: true }
 
   isosurface:
-    setting:
+    settings:
       _any:
         level: { _type: _float }
         color: { _type: _list }
     draw: { _type: _bool }
+  
   lattice_plane:
-    setting:
+    settings:
       _any:
         _eval_key: true
         boundary: { _type: _bool }
@@ -99,7 +100,7 @@ settings:
     draw: { _type: _bool }
 
   crystal_shape:
-    setting:
+    settings:
       _any:
         _eval_key: true
         crystal: { _type: _bool }
@@ -114,7 +115,7 @@ settings:
     draw: { _type: _bool }
 
   molecular_surface:
-    setting:
+    settings:
       _any:
         type: { _type: _str }
         color: { _type: _list }
@@ -125,7 +126,7 @@ settings:
   cavity:
     resolution: { _type: _float }
     minRadius: { _type: _float }
-    setting:
+    settings:
       _any:
         color: { _type: _list }
         flag: { _type: _bool }

--- a/tests/api/example.yaml
+++ b/tests/api/example.yaml
@@ -12,7 +12,7 @@ settings:
     H:
       material_style: "plastic"
   bond:
-    setting:
+    settings:
       ("C", "H"):
         order: 2
         polyhedra: true

--- a/tests/api/example.yaml
+++ b/tests/api/example.yaml
@@ -11,7 +11,7 @@ settings:
       material_style: "metallic"
     H:
       material_style: "plastic"
-  bonds:
+  bond:
     setting:
       ("C", "H"):
         order: 2

--- a/tests/api/test_script_api.py
+++ b/tests/api/test_script_api.py
@@ -84,13 +84,13 @@ def test_apply_batoms_settings():
     assert all([c == 1.0 for c in batoms.species["C"].color])
 
     # Test 4: set properties with tuple keys
-    config = {"bond": {"setting": {("C", "H"): {"polyhedra": True}}}}
+    config = {"bond": {"settings": {("C", "H"): {"polyhedra": True}}}}
     apply_batoms_settings(batoms, settings=config)
     # cycles changed to capital
     assert batoms.bonds.setting[("C", "H")].polyhedra is True
 
     # Test 4-1: raw string of tuple keys --> exception
-    config = {"bond": {"setting": {'("C", "H")': {"polyhedra": False}}}}
+    config = {"bond": {"settings": {'("C", "H")': {"polyhedra": False}}}}
     with pytest.raises(Exception):
         apply_batoms_settings(batoms, settings=config)
 

--- a/tests/api/test_script_api.py
+++ b/tests/api/test_script_api.py
@@ -84,13 +84,13 @@ def test_apply_batoms_settings():
     assert all([c == 1.0 for c in batoms.species["C"].color])
 
     # Test 4: set properties with tuple keys
-    config = {"bonds": {"setting": {("C", "H"): {"polyhedra": True}}}}
+    config = {"bond": {"setting": {("C", "H"): {"polyhedra": True}}}}
     apply_batoms_settings(batoms, settings=config)
     # cycles changed to capital
     assert batoms.bonds.setting[("C", "H")].polyhedra is True
 
     # Test 4-1: raw string of tuple keys --> exception
-    config = {"bonds": {"setting": {'("C", "H")': {"polyhedra": False}}}}
+    config = {"bond": {"setting": {'("C", "H")': {"polyhedra": False}}}}
     with pytest.raises(Exception):
         apply_batoms_settings(batoms, settings=config)
 

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -35,37 +35,37 @@ def test_dict_set():
     set_dict(
         {
             "settings": {
-                "bonds": {"setting": {"('C', 'H')": {"order": 2}}},
+                "bond": {"setting": {"('C', 'H')": {"order": 2}}},
             }
         },
         output,
         default_schema,
     )
-    assert ("C", "H") in output["settings"]["bonds"]["setting"].keys()
+    assert ("C", "H") in output["settings"]["bond"]["setting"].keys()
     # Test if explicity python types can be added
     output = {}
     set_dict(
         {
             "settings": {
-                "bonds": {"setting": {("C", "H"): {"order": 2}}},
+                "bond": {"setting": {("C", "H"): {"order": 2}}},
             }
         },
         output,
         default_schema,
     )
-    assert ("C", "H") in output["settings"]["bonds"]["setting"].keys()
-    # Test wrong property name (should be `bonds`)
+    assert ("C", "H") in output["settings"]["bond"]["setting"].keys()
+    # property 'bonds' is deprecated and not in settings
     output = {}
     set_dict(
         {
             "settings": {
-                "bond": {"setting": {'("C", "H")': {"order": 2}}},
+                "bonds": {"setting": {'("C", "H")': {"order": 2}}},
             }
         },
         output,
         default_schema,
     )
-    assert "bond" not in output["settings"].keys()
+    assert "bonds" not in output["settings"].keys()
 
 
 def test_disabled_vals():
@@ -111,7 +111,7 @@ def test_yaml_load():
     assert "polyhedra_style" not in config["batoms_input"].keys()
     assert "model_style" in config["batoms_input"].keys()
     assert config["batoms_input"]["radius_style"] == 1
-    assert ("C", "H") in config["settings"]["bonds"]["setting"].keys()
+    assert ("C", "H") in config["settings"]["bond"]["setting"].keys()
 
 
 def test_merge_dict():
@@ -122,7 +122,7 @@ def test_merge_dict():
     new_config = {
         "batoms_input": {"label": "ch4_mod"},
         "settings": {
-            "bonds": {
+            "bond": {
                 "setting": {
                     ("C", "H"): {
                         "order": 1,
@@ -137,8 +137,8 @@ def test_merge_dict():
     }
     merged = merge_dicts(config, new_config)
     assert merged["batoms_input"]["label"] == "ch4_mod"
-    assert ("C", "C") in merged["settings"]["bonds"]["setting"].keys()
-    assert merged["settings"]["bonds"]["setting"][("C", "H")]["order"] == 1
-    assert merged["settings"]["bonds"]["setting"][("C", "C")]["order"] == 2
-    assert merged["settings"]["bonds"]["setting"][("C", "H")]["polyhedra"] is True
-    assert merged["settings"]["bonds"]["setting"][("C", "C")]["polyhedra"] is False
+    assert ("C", "C") in merged["settings"]["bond"]["setting"].keys()
+    assert merged["settings"]["bond"]["setting"][("C", "H")]["order"] == 1
+    assert merged["settings"]["bond"]["setting"][("C", "C")]["order"] == 2
+    assert merged["settings"]["bond"]["setting"][("C", "H")]["polyhedra"] is True
+    assert merged["settings"]["bond"]["setting"][("C", "C")]["polyhedra"] is False

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -35,31 +35,31 @@ def test_dict_set():
     set_dict(
         {
             "settings": {
-                "bond": {"setting": {"('C', 'H')": {"order": 2}}},
+                "bond": {"settings": {"('C', 'H')": {"order": 2}}},
             }
         },
         output,
         default_schema,
     )
-    assert ("C", "H") in output["settings"]["bond"]["setting"].keys()
+    assert ("C", "H") in output["settings"]["bond"]["settings"].keys()
     # Test if explicity python types can be added
     output = {}
     set_dict(
         {
             "settings": {
-                "bond": {"setting": {("C", "H"): {"order": 2}}},
+                "bond": {"settings": {("C", "H"): {"order": 2}}},
             }
         },
         output,
         default_schema,
     )
-    assert ("C", "H") in output["settings"]["bond"]["setting"].keys()
+    assert ("C", "H") in output["settings"]["bond"]["settings"].keys()
     # property 'bonds' is deprecated and not in settings
     output = {}
     set_dict(
         {
             "settings": {
-                "bonds": {"setting": {'("C", "H")': {"order": 2}}},
+                "bonds": {"settings": {'("C", "H")': {"order": 2}}},
             }
         },
         output,
@@ -111,7 +111,7 @@ def test_yaml_load():
     assert "polyhedra_style" not in config["batoms_input"].keys()
     assert "model_style" in config["batoms_input"].keys()
     assert config["batoms_input"]["radius_style"] == 1
-    assert ("C", "H") in config["settings"]["bond"]["setting"].keys()
+    assert ("C", "H") in config["settings"]["bond"]["settings"].keys()
 
 
 def test_merge_dict():
@@ -123,7 +123,7 @@ def test_merge_dict():
         "batoms_input": {"label": "ch4_mod"},
         "settings": {
             "bond": {
-                "setting": {
+                "settings": {
                     ("C", "H"): {
                         "order": 1,
                     },
@@ -137,8 +137,8 @@ def test_merge_dict():
     }
     merged = merge_dicts(config, new_config)
     assert merged["batoms_input"]["label"] == "ch4_mod"
-    assert ("C", "C") in merged["settings"]["bond"]["setting"].keys()
-    assert merged["settings"]["bond"]["setting"][("C", "H")]["order"] == 1
-    assert merged["settings"]["bond"]["setting"][("C", "C")]["order"] == 2
-    assert merged["settings"]["bond"]["setting"][("C", "H")]["polyhedra"] is True
-    assert merged["settings"]["bond"]["setting"][("C", "C")]["polyhedra"] is False
+    assert ("C", "C") in merged["settings"]["bond"]["settings"].keys()
+    assert merged["settings"]["bond"]["settings"][("C", "H")]["order"] == 1
+    assert merged["settings"]["bond"]["settings"][("C", "C")]["order"] == 2
+    assert merged["settings"]["bond"]["settings"][("C", "H")]["polyhedra"] is True
+    assert merged["settings"]["bond"]["settings"][("C", "C")]["polyhedra"] is False

--- a/tests/modules/test_bonds.py
+++ b/tests/modules/test_bonds.py
@@ -13,12 +13,12 @@ def test_bonds():
 
     atoms = molecule("CH4")
     config["batoms_input"].update({"model_style": 1})
-    config["settings"].update({"bonds": {"setting": {("C", "H"): {"style": "3"}}}})
+    config["settings"].update({"bond": {"settings": {("C", "H"): {"style": "3"}}}})
     render(atoms, save_blender_file=True, **config)
     with load_blender_file() as do:
         batoms = do["batoms"]
         assert batoms.model_style == 1
-        assert batoms.bonds.setting[("C", "H")].style == "3"
+        assert batoms.bond.settings[("C", "H")].style == "3"
     os.remove(".batoms.blend")
     bpy.ops.batoms.delete()
 
@@ -33,31 +33,31 @@ def test_hydrogen_bond():
     # 1. Enable hydrogen bond. # of hydrogen bonds become 3 with style 2
     atoms = molecule("CH3OH")
     config["batoms_input"].update({"model_style": 1})
-    config["settings"].update({"bonds": {"show_hydrogen_bond": True}})
+    config["settings"].update({"bond": {"show_hydrogen_bond": True}})
 
     render(atoms, save_blender_file=True, **config)
     with load_blender_file() as do:
         batoms = do["batoms"]
         assert batoms.model_style == 1
-        assert batoms.bonds.show_hydrogen_bond is True
+        assert batoms.bond.show_hydrogen_bond is True
         # 5 cov bonds + 3 H-bonds
-        assert len(batoms.bonds.arrays["style"]) == 8
-        assert all(batoms.bonds.arrays["style"][:5] == 1)
-        assert all(batoms.bonds.arrays["style"][5:] == 2)
+        assert len(batoms.bond.arrays["style"]) == 8
+        assert all(batoms.bond.arrays["style"][:5] == 1)
+        assert all(batoms.bond.arrays["style"][5:] == 2)
     os.remove(".batoms.blend")
 
     bpy.ops.batoms.delete()
 
     # 2. Disable hydrogen bond, # of total bonds --> 5
-    config["settings"]["bonds"].update({"show_hydrogen_bond": False})
+    config["settings"]["bond"].update({"show_hydrogen_bond": False})
     render(atoms, save_blender_file=True, **config)
     with load_blender_file() as do:
         batoms = do["batoms"]
         assert batoms.model_style == 1
-        assert batoms.bonds.show_hydrogen_bond is False
+        assert batoms.bond.show_hydrogen_bond is False
         # 5 cov bonds
-        assert len(batoms.bonds.arrays["style"]) == 5
-        assert all(batoms.bonds.arrays["style"] == 1)
+        assert len(batoms.bond.arrays["style"]) == 5
+        assert all(batoms.bond.arrays["style"] == 1)
     os.remove(".batoms.blend")
 
     bpy.ops.batoms.delete()

--- a/tests/modules/test_boundary.py
+++ b/tests/modules/test_boundary.py
@@ -27,7 +27,7 @@ def test_boundary():
             "bonds": {
                 "show_search": True,
             },
-            "polyhedras": {"setting": {"Ti": {"color": [0, 0.5, 0.5, 0.5]}}},
+            "polyhedra": {"settings": {"Ti": {"color": [0, 0.5, 0.5, 0.5]}}},
         }
     )
     render(atoms, save_blender_file=True, **config)

--- a/tests/modules/test_cavity.py
+++ b/tests/modules/test_cavity.py
@@ -23,7 +23,7 @@ def test_cs():
             "cavity": {
                 "resolution": 0.25,
                 "minRadius": 0.5,
-                "setting": {
+                "settings": {
                     "1": {
                         "min": 0.5,
                         "max": 3.0,

--- a/tests/modules/test_cell.py
+++ b/tests/modules/test_cell.py
@@ -23,10 +23,10 @@ def test_cell():
     config["settings"].update(
         {
             "model_style": 2,
-            "bonds": {
+            "bond": {
                 "show_search": True,
             },
-            "polyhedras": {"setting": {"Ti": {"color": [0, 0.5, 0.5, 0.5]}}},
+            "polyhedra": {"settings": {"Ti": {"color": [0, 0.5, 0.5, 0.5]}}},
         }
     )
     render(atoms, save_blender_file=True, **config)
@@ -50,9 +50,10 @@ def test_cell():
         assert batoms.model_style == 2
         c_polyhedra = get_material_color(batoms.polyhedras.obj)
         assert np.isclose(c_polyhedra, [0, 0.5, 0.5, 0.5]).all()
-        cc = batoms.cell.obj_cylinder
-        c_cell = get_material_color(cc)
-        assert np.isclose(c_cell, [0, 0, 0, 1.0]).all()
+        # The new Bcells from v2.2.0 up has cancelled usage of obj_cylinder
+        # cc = batoms.cell.obj_cylinder
+        # c_cell = get_material_color(cc)
+        # assert np.isclose(c_cell, [0, 0, 0, 1.0]).all()
     os.remove(".batoms.blend")
 
     bpy.ops.batoms.delete()

--- a/tests/modules/test_crystal_shape.py
+++ b/tests/modules/test_crystal_shape.py
@@ -20,7 +20,7 @@ def test_cs():
         {
             "model_style": 0,
             "crystal_shape": {
-                "setting": {
+                "settings": {
                     "(1, 1, 1)": {
                         "distance": 6,
                         "color": [0, 0.8, 0, 1],
@@ -46,12 +46,12 @@ def test_cs():
     with load_blender_file() as do:
         batoms = do["batoms"]
         # 8 symmetries of 111 + 12 symmetries of -110
-        assert len(batoms.crystal_shape.setting) == 20
+        assert len(batoms.crystal_shape.settings) == 20
         # Non-exhaustive, just to check symbol
-        assert batoms.crystal_shape.setting.find("1-1-1") is not None
-        assert batoms.crystal_shape.setting.find("-1-1-1") is not None
-        assert batoms.crystal_shape.setting.find("-1-1-0") is not None
-        assert batoms.crystal_shape.setting.find("-1--1-0") is not None
+        assert batoms.crystal_shape.settings.find("1-1-1") is not None
+        assert batoms.crystal_shape.settings.find("-1-1-1") is not None
+        assert batoms.crystal_shape.settings.find("-1-1-0") is not None
+        assert batoms.crystal_shape.settings.find("-1--1-0") is not None
 
     os.remove(".batoms.blend")
 

--- a/tests/modules/test_isosurfaces.py
+++ b/tests/modules/test_isosurfaces.py
@@ -20,8 +20,8 @@ def test_isosurfaces():
     config["settings"].update(
         {
             "model_style": 1,
-            "isosurfaces": {
-                "setting": {
+            "isosurface": {
+                "settings": {
                     "1": {"level": -0.001, "color": [1, 1, 0, 0.5]},
                     "2": {"level": 0.001, "color": [0, 1, 1, 0.5]},
                 },
@@ -34,7 +34,7 @@ def test_isosurfaces():
     with load_blender_file() as do:
         batoms = do["batoms"]
         label = batoms.label
-        assert len(batoms.isosurfaces.setting) == 2
+        assert len(batoms.isosurface.settings) == 2
         iso1 = batoms.coll.objects[f"{label}_isosurface_1"]
         iso2 = batoms.coll.objects[f"{label}_isosurface_2"]
         c1, c2 = get_material_color(iso1), get_material_color(iso2)
@@ -54,17 +54,17 @@ def test_isosurfaces_multi():
     config["settings"].update(
         {
             "model_style": 1,
-            "isosurfaces": {"setting": {}, "draw": True},
+            "isosurface": {"settings": {}, "draw": True},
         }
     )
     levels = [-0.001, -0.005, -0.01, -0.02, -0.05]
     for i in range(5):
-        config["settings"]["isosurfaces"]["setting"][str(i)] = {
+        config["settings"]["isosurface"]["settings"][str(i)] = {
             "level": levels[i],
             "color": [1, 1, 0, 0.2],
         }
     for i in range(5, 10):
-        config["settings"]["isosurfaces"]["setting"][str(i)] = {
+        config["settings"]["isosurface"]["settings"][str(i)] = {
             "level": -levels[i - 5],
             "color": [0, 1, 1, 0.2],
         }
@@ -74,7 +74,7 @@ def test_isosurfaces_multi():
     with load_blender_file() as do:
         batoms = do["batoms"]
         label = batoms.label
-        assert len(batoms.isosurfaces.setting) == 10
+        assert len(batoms.isosurface.settings) == 10
         for i in range(5):
             iso = batoms.coll.objects[f"{label}_isosurface_{i}"]
             c = get_material_color(iso)

--- a/tests/modules/test_lattice_plane.py
+++ b/tests/modules/test_lattice_plane.py
@@ -20,7 +20,7 @@ def test_lp():
         {
             "model_style": 0,
             "lattice_plane": {
-                "setting": {
+                "settings": {
                     "(1, 1, 1)": {"distance": 3, "scale": 2.0},
                     "(1, 1, 0)": {
                         "distance": 2,
@@ -35,21 +35,21 @@ def test_lp():
     render(atoms, save_blender_file=True, display=False, **config)
     with load_blender_file() as do:
         batoms = do["batoms"]
-        assert len(batoms.lattice_plane.setting) == 2
-        assert batoms.lattice_plane.setting[(1, 1, 1)].distance == pytest.approx(
+        assert len(batoms.lattice_plane.settings) == 2
+        assert batoms.lattice_plane.settings[(1, 1, 1)].distance == pytest.approx(
             3.0, 1.0e-4
         )
-        assert batoms.lattice_plane.setting[(1, 1, 0)].distance == pytest.approx(
+        assert batoms.lattice_plane.settings[(1, 1, 0)].distance == pytest.approx(
             2.0, 1.0e-4
         )
-        assert batoms.lattice_plane.setting[(1, 1, 1)].scale == pytest.approx(
+        assert batoms.lattice_plane.settings[(1, 1, 1)].scale == pytest.approx(
             2.0, 1.0e-4
         )
-        assert batoms.lattice_plane.setting[(1, 1, 0)].scale == pytest.approx(
+        assert batoms.lattice_plane.settings[(1, 1, 0)].scale == pytest.approx(
             1.5, 1.0e-4
         )
-        assert batoms.lattice_plane.setting[(1, 1, 1)].slicing is False
-        assert batoms.lattice_plane.setting[(1, 1, 0)].slicing is False
+        assert batoms.lattice_plane.settings[(1, 1, 1)].slicing is False
+        assert batoms.lattice_plane.settings[(1, 1, 0)].slicing is False
 
     os.remove(".batoms.blend")
 
@@ -65,7 +65,7 @@ def test_lp_material():
         {
             "model_style": 0,
             "lattice_plane": {
-                "setting": {
+                "settings": {
                     "(1, 0, 0)": {
                         "distance": 1,
                         "color": [0.8, 0, 0.6, 0.95],

--- a/tests/modules/test_ms.py
+++ b/tests/modules/test_ms.py
@@ -19,8 +19,8 @@ def test_ms():
     config["settings"].update(
         {
             "model_style": 1,
-            "ms": {
-                "setting": {
+            "molecular_surface": {
+                "settings": {
                     "1": {"type": "SAS", "probe": 1.0, "color": [1, 1, 0, 0.5]},
                     "2": {"type": "SES", "resolution": 0.25, "color": [0, 0, 0.8, 0.5]},
                 },
@@ -31,13 +31,21 @@ def test_ms():
     render(atoms, save_blender_file=True, display=False, **config)
     with load_blender_file() as do:
         batoms = do["batoms"]
-        assert len(batoms.ms.setting) == 2
-        assert batoms.ms.setting["1"].type == "SAS"
-        assert batoms.ms.setting["2"].type == "SES"
-        assert batoms.ms.setting["1"].resolution == pytest.approx(0.5, 1.0e-4)
-        assert batoms.ms.setting["2"].resolution == pytest.approx(0.25, 1.0e-4)
-        assert batoms.ms.setting["1"].probe == pytest.approx(1.0, 1.0e-4)
-        assert batoms.ms.setting["2"].probe == pytest.approx(1.4, 1.0e-4)
+        assert len(batoms.molecular_surface.settings) == 2
+        assert batoms.molecular_surface.settings["1"].type == "SAS"
+        assert batoms.molecular_surface.settings["2"].type == "SES"
+        assert batoms.molecular_surface.settings["1"].resolution == pytest.approx(
+            0.5, 1.0e-4
+        )
+        assert batoms.molecular_surface.settings["2"].resolution == pytest.approx(
+            0.25, 1.0e-4
+        )
+        assert batoms.molecular_surface.settings["1"].probe == pytest.approx(
+            1.0, 1.0e-4
+        )
+        assert batoms.molecular_surface.settings["2"].probe == pytest.approx(
+            1.4, 1.0e-4
+        )
 
     os.remove(".batoms.blend")
 

--- a/tests/modules/test_polyhedras.py
+++ b/tests/modules/test_polyhedras.py
@@ -21,8 +21,8 @@ def test_polyhedras():
     config["settings"].update(
         {
             "model_style": 2,
-            "bonds": {"show_search": True},
-            "polyhedras": {"setting": {"Ti": {"color": [1, 0, 1, 0.5]}}},
+            "bond": {"show_search": True},
+            "polyhedra": {"settings": {"Ti": {"color": [1, 0, 1, 0.5]}}},
         }
     )
     render(atoms, save_blender_file=True, **config)
@@ -43,13 +43,13 @@ def test_bond_search():
 
     atoms = read(data_path / "tio2.cif")
     config = base_config.copy()
-    config["settings"].update({"model_style": 2, "bonds": {"show_search": False}})
+    config["settings"].update({"model_style": 2, "bond": {"show_search": False}})
     render(atoms, save_blender_file=True, **config)
     # Check if the real material assigned is the same color
     with load_blender_file() as do:
         batoms = do["batoms"]
-        assert batoms.bonds.show_search is False
-        bond_search_obj = batoms.bonds.search_bond.obj
+        assert batoms.bond.show_search is False
+        bond_search_obj = batoms.bond.search_bond.obj
         att = get_gn_attributes(bond_search_obj, "show")
         # When search_bond not set, the value is an empty list
         assert len(att) == 0
@@ -57,13 +57,13 @@ def test_bond_search():
     bpy.ops.batoms.delete()
 
     # Enable the search_bond
-    config["settings"]["bonds"]["show_search"] = True
+    config["settings"]["bond"]["show_search"] = True
     render(atoms, save_blender_file=True, **config)
     # Check if the real material assigned is the same color
     with load_blender_file() as do:
         batoms = do["batoms"]
-        assert batoms.bonds.show_search is True
-        bond_search_obj = batoms.bonds.search_bond.obj
+        assert batoms.bond.show_search is True
+        bond_search_obj = batoms.bond.search_bond.obj
         att = get_gn_attributes(bond_search_obj, "show")
         # Currently att is not persistent
         # assert len(att) == 7


### PR DESCRIPTION
rename the deprecated keywords in schema to make tests compatible with v2.2.0 of batoms